### PR TITLE
allow override of endpoint_url and api version

### DIFF
--- a/lib/aliyun/ecs.rb
+++ b/lib/aliyun/ecs.rb
@@ -12,7 +12,9 @@ module Aliyun
         def initialize(options={})
             Aliyun[:access_key_id] = options[:access_key_id] || Aliyun[:access_key_id] || ENV['ALIYUN_ACCESS_KEY_ID']
             Aliyun[:access_key_secret] = options[:access_key_secret] || Aliyun[:access_key_secret] || ENV['ALIYUN_ACCESS_KEY_SECRET']
-            Aliyun[:endpoint_url] ||= options[:endpoint_url]
+            Aliyun[:endpoint_url] = options[:endpoint_url] || Aliyun[:endpoint_url]
+            Aliyun[:request_parameters][:Version] = options[:version] || Aliyun[:version]
+
         end
         
         def method_missing(method_name, *args,&block)


### PR DESCRIPTION
i.e. to request the load balancer api we can call ECS with

options = {
           :access_key_id => "foo",
           :access_key_secret => "bar",
           :endpoint_url => "https://slb.aliyuncs.com/",
           :version => "2014-05-15"
}
