### PR TITLE
fix bug. request parameter "Version" is nil

### DIFF
--- a/lib/aliyun/ecs.rb
+++ b/lib/aliyun/ecs.rb
@@ -13,7 +13,7 @@ module Aliyun
             Aliyun[:access_key_id] = options[:access_key_id] || Aliyun[:access_key_id] || ENV['ALIYUN_ACCESS_KEY_ID']
             Aliyun[:access_key_secret] = options[:access_key_secret] || Aliyun[:access_key_secret] || ENV['ALIYUN_ACCESS_KEY_SECRET']
             Aliyun[:endpoint_url] = options[:endpoint_url] || Aliyun[:endpoint_url]
-            Aliyun[:request_parameters][:Version] = options[:version] || Aliyun[:version]
+            Aliyun[:request_parameters][:Version] = options[:version] || Aliyun[:version] || Aliyun[:request_parameters][:Version]
 
         end
         


### PR DESCRIPTION
Hello.

aliyun-api-0.1.0 occur error as below. 

```
Aliyun::AliyunError: response error: [The input parameter "Version" that is mandatory for processing this request is not supplied.] 400 Bad Request
```
