### PR TITLE
Avoid JSON parse exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 *.gem
+.idea

--- a/lib/aliyun/ecs.rb
+++ b/lib/aliyun/ecs.rb
@@ -29,7 +29,8 @@ module Aliyun
             block.call params if block
             begin
                 res = RestClient.send Aliyun[:request_method].downcase, Aliyun[:endpoint_url], {:params => params,:verify_ssl => OpenSSL::SSL::VERIFY_PEER }
-                return JSON.parse res.body if res.code == 200
+                return JSON.parse res.body if res.code == 200 and res.body.length >= 2
+                return {}
             rescue RestClient::Exception => rcex
                 message = JSON.parse(rcex.response)
                 raise AliyunError.new "response error: [#{message['Message']}] #{rcex.to_s}\nrequest parameters: #{params.reject{|k,v| k==:AccessKeyId}}"


### PR DESCRIPTION
When ```res.body.length < 2```,  it will rails an exception ```A JSON text must at least contain two octets!```
In this situation, the response should be OK, but requested data is empty. So we should return an empty JSON object rather than an exception.